### PR TITLE
fix: autoreformat mistake

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,6 @@ class ServerlessPlugin {
         }
       }
       return newVersion
-
     }
 
     const putSsmParameter = (name, value) => new Promise((resolve, reject) => {
@@ -69,10 +68,8 @@ class ServerlessPlugin {
       SSM.putParameter(params, (err, data) => {
         if (err) { reject(err); }
         else { resolve(data); }
-
       });
     });
-
 
     const ssmPrefix = (this.serverless.service.custom
       && this.serverless.service.custom.ssmApiVersion

--- a/index.js
+++ b/index.js
@@ -71,23 +71,24 @@ class ServerlessPlugin {
         else { resolve(data); }
 
       });
+    });
 
 
-      const ssmPrefix = (this.serverless.service.custom
-        && this.serverless.service.custom.ssmApiVersion
-        && this.serverless.service.custom.ssmApiVersion.ssmPrefix)
-        ? this.serverless.service.custom.ssmApiVersion.ssmPrefix.replace(/<stage>/g, stage)
-        : `/app/${stage}/versions/`;
-      const ssmParameterName = ssmPrefix + this.serverless.service.service;
+    const ssmPrefix = (this.serverless.service.custom
+      && this.serverless.service.custom.ssmApiVersion
+      && this.serverless.service.custom.ssmApiVersion.ssmPrefix)
+      ? this.serverless.service.custom.ssmApiVersion.ssmPrefix.replace(/<stage>/g, stage)
+      : `/app/${stage}/versions/`;
+    const ssmParameterName = ssmPrefix + this.serverless.service.service;
 
-      getSsmParameter(ssmParameterName)
-        .then(value => {
-          this.serverless.cli.log(`SSM API version: current version '${value}'`);
-          const incrementedVersion = incrementVersion(value.toString())
-          this.serverless.cli.log(`SSM API version: Updating new version '${incrementedVersion}' to SSM with key '${ssmParameterName}' at region ${region}`);
-          return putSsmParameter(ssmParameterName, incrementedVersion);
-        });
-    }
+    getSsmParameter(ssmParameterName)
+      .then(value => {
+        this.serverless.cli.log(`SSM API version: current version '${value}'`);
+        const incrementedVersion = incrementVersion(value.toString())
+        this.serverless.cli.log(`SSM API version: Updating new version '${incrementedVersion}' to SSM with key '${ssmParameterName}' at region ${region}`);
+        return putSsmParameter(ssmParameterName, incrementedVersion);
+      });
+  }
 }
 
 module.exports = ServerlessPlugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-ssm-version-tracker",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Track and increment versions of Serverless framework projects in SSM",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Autoreformat had removed '})' characters from line 74 which caused
whole plugin to fail. Added that back and reformatted indentation